### PR TITLE
fix: remove `hdd` tier restriction for ['fi-hel', 'sg-sin', 'uk-lon']

### DIFF
--- a/modules/servers/upCloudVm/Manager.php
+++ b/modules/servers/upCloudVm/Manager.php
@@ -150,15 +150,7 @@ class Manager
         $zone = ($this->params['configoptions']['Location'] == '') ? $this->params['configoption1'] : $this->params['configoptions']['Location'];
         $size = ($this->params['configoptions']['Storage'] == '') ? 10 : $this->params['configoptions']['Storage'];
 
-        $hddAvaliable = ['fi-hel', 'sg-sin', 'uk-lon'];
         $tier = 'maxiops';
-
-        foreach ($hddAvaliable as $zon) {
-            if (strpos($zone, $zon) !== false) {
-                $tier = 'hdd';
-                break;
-            }
-        }
 
         if (empty($this->params['domain'])) {
             $this->params['domain'] = '127.0.0.1';


### PR DESCRIPTION
Default to `maxiops` for all regions.
Based on the API docs at https://developers.upcloud.com/1.3/8-servers/#create-server it looks like `maxiops` is supported for `fi-hel` region.

![image](https://user-images.githubusercontent.com/14059086/81991307-de4acb00-9638-11ea-9089-f6b5bf1bf790.png)
