### PR TITLE
refactor: change module display name to "UpCloud Server"

### DIFF
--- a/modules/servers/upCloudVps/upCloudVps.php
+++ b/modules/servers/upCloudVps/upCloudVps.php
@@ -14,7 +14,7 @@ use WHMCS\Module\Server\upCloudVps\configOptions;
 function upCloudVps_MetaData()
 {
     return [
-        'DisplayName' => 'upCloud VPS',
+        'DisplayName' => 'UpCloud Server',
         'APIVersion' => '1.3',
         'ServiceSingleSignOnLabel' => 'Login to Panel as User',
         'RequiresServer' => true,


### PR DESCRIPTION
UpCloud is spelled with a capital "U", and we do not currently use the term "VPS" with our products.

The previous version of the UpCloud WHMCS module used "UpCloud VM" which would likely be ok as well, but better to differentiate in case both old and this version of the module are both installed.