### PR TITLE
fix: remove old inactive WHMCS version support mentions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,5 +33,5 @@ jobs:
           WHMCSMP_LOGIN: ${{ secrets.WHMCSMP_LOGIN }}
           WHMCSMP_PASSWORD: ${{ secrets.WHMCSMP_PASSWORD }}
           WHMCSMP_PRODUCTID: "7770"
-          WHMCSMP_MINVERSION: "7.0"
+          WHMCSMP_MINVERSION: "8.10"
         run: npx semantic-release

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ This is the official WHMCS provisioning module for [UpCloud](https://upcloud.com
 
 ## Requirements
 
-- WHMCS 7.x or later
-- PHP 7.0 or later
+- WHMCS 8.10 or later
 - UpCloud API credentials
 
 ## Installation


### PR DESCRIPTION
While at it, remove redundant and obsolete PHP version requirement.

Note: "incorrectly" marked as a `fix` to try out semantic-release for real.