### PR TITLE
chore(ci): do not persist checkout credentials

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22


### PR DESCRIPTION
Hopefully makes semantic-release/git push creds to actually take effect.

Refs https://github.com/semantic-release/git/issues/196#issuecomment-601310576