### PR TITLE
chore: remove redundant phpcbf extensions arg

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <exclude-pattern type="relative">^vendor/*</exclude-pattern>
-  <arg name="extensions" value="php"/>
   <rule ref="PSR12"/>
 </ruleset>


### PR DESCRIPTION
Default is `php,inc` which works for us.